### PR TITLE
Split picking out logics into polyfills function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Split picking out logics into `polyfills()` function ([#1](https://github.com/marp-team/marpit-svg-polyfill/pull/1))
+
 ## v0.0.1 - 2018-12-29
 
 - Initial release.

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,2 +1,2 @@
 /* istanbul ignore file */
-export { observe as default, observe, webkit } from './polyfill'
+export { observe as default, observe, polyfills, webkit } from './polyfill'

--- a/test/polyfill.browser.ts
+++ b/test/polyfill.browser.ts
@@ -3,7 +3,7 @@ import { observe } from '../src/polyfill'
 jest.mock('../src/polyfill')
 
 describe('Browser bundle', () => {
-  it('executes polyfill', () => {
+  it('observes to apply polyfill', () => {
     require('../src/polyfill.browser')
     expect(observe).toBeCalledTimes(1)
   })

--- a/test/polyfill.ts
+++ b/test/polyfill.ts
@@ -1,8 +1,17 @@
 import { Marpit } from '@marp-team/marpit'
 import detectBrowser from 'detect-browser'
-import { observe, symbolObserver, webkit } from '../src/polyfill'
+import {
+  observe,
+  resetPolyfills,
+  symbolObserver,
+  webkit,
+} from '../src/polyfill'
 
-beforeEach(() => (window[symbolObserver] = false))
+beforeEach(() => {
+  resetPolyfills()
+  window[symbolObserver] = false
+})
+
 afterEach(() => jest.restoreAllMocks())
 
 describe('Marpit SVG polyfill', () => {


### PR DESCRIPTION
Add `polyfills` function to split picking out logics. It would use in [@marp-team/marp-core](https://github.com/marp-team/marp-core).