### PR TITLE
Fix incorrect scaling in split background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix incorrect scaling in split background ([#2](https://github.com/marp-team/marpit-svg-polyfill/pull/2))
+
 ## v0.1.0 - 2018-12-29
 
 - Split picking out logics into `polyfills()` function ([#1](https://github.com/marp-team/marpit-svg-polyfill/pull/1))

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -52,21 +52,30 @@ export function webkit() {
       const { clientHeight, clientWidth } = svg
       if (!svg.style.transform) svg.style.transform = 'translateZ(0)'
 
-      Array.from(svg.getElementsByTagName('foreignObject'), foreignObject => {
-        const foWidth = foreignObject.clientWidth
-        const foHeight = foreignObject.clientHeight
-        const scale = Math.min(clientHeight / foHeight, clientWidth / foWidth)
+      const { width, height } = svg.viewBox.baseVal
+      const scale = Math.min(clientHeight / height, clientWidth / width)
 
-        Array.from(foreignObject.getElementsByTagName('section'), section => {
-          if (!section.style.transformOrigin) {
-            section.style.transformOrigin = '0 0'
-          }
+      Array.from(
+        svg.querySelectorAll<SVGForeignObjectElement>(':scope > foreignObject'),
+        foreignObject => {
+          const x = foreignObject.x.baseVal.value
+          const y = foreignObject.y.baseVal.value
 
-          section.style.transform = `translate3d(${clientWidth / 2 -
-            (scale * foWidth) / 2}px,${clientHeight / 2 -
-            (scale * foHeight) / 2}px,0) scale(${scale})`
-        })
-      })
+          Array.from(
+            foreignObject.querySelectorAll<HTMLElement>(':scope > section'),
+            section => {
+              if (!section.style.transformOrigin) {
+                section.style.transformOrigin = '0 0'
+              }
+
+              const tx = (clientWidth - scale * width) / 2 - x
+              const ty = (clientHeight - scale * height) / 2 - y
+
+              section.style.transform = `translate3d(${tx}px,${ty}px,0) scale(${scale}) translate(${x}px,${y}px)`
+            }
+          )
+        }
+      )
     }
   })
 }

--- a/test/polyfill.ts
+++ b/test/polyfill.ts
@@ -43,6 +43,30 @@ describe('Marpit SVG polyfill', () => {
     beforeEach(() => {
       const marpit = new Marpit({ inlineSVG: true })
       document.body.innerHTML = marpit.render('').html
+
+      Array.from(document.querySelectorAll('svg'), (svg: any) => {
+        svg.viewBox = { baseVal: { width: 1280, height: 720 } }
+
+        const foreignObjects = Array.from(
+          svg.querySelectorAll('foreignObject'),
+          (foreignObject: any) => {
+            foreignObject.x = { baseVal: { value: 0 } }
+            foreignObject.y = { baseVal: { value: 0 } }
+
+            // mock for unsupported `:scope` selector
+            jest
+              .spyOn(foreignObject, 'querySelectorAll')
+              .mockImplementation(() => document.querySelectorAll('section'))
+
+            return foreignObject
+          }
+        )
+
+        // mock for unsupported `:scope` selector
+        jest
+          .spyOn(svg, 'querySelectorAll')
+          .mockImplementation(() => foreignObjects)
+      })
     })
 
     it('applies transform style to SVG element for repainting', () => {


### PR DESCRIPTION
Marpit's split background has a thin width `<foreignObject width="50%">` sometimes. This PR will fix scaling for these elements.