### PR TITLE
Simplify WebKit detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Simplify WebKit detection (JS build for browser become about 5x smaller) ([#9](https://github.com/marp-team/marpit-svg-polyfill/pull/9))
+
 ## v1.0.0 - 2019-06-05
 
 ### Breaking

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       }
     },
     "preset": "ts-jest",
+    "restoreMocks": true,
     "testMatch": [
       "<rootDir>/test/**/*.[jt]s"
     ]
@@ -65,6 +66,7 @@
   "devDependencies": {
     "@marp-team/marpit": "^1.1.0",
     "@types/jest": "^24.0.13",
+    "@types/node": "^12.0.8",
     "codecov": "^3.5.0",
     "jest": "^24.8.0",
     "jest-junit": "^6.4.0",
@@ -83,9 +85,6 @@
     "tslint-config-airbnb": "^5.11.1",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.5.1"
-  },
-  "dependencies": {
-    "detect-browser": "^4.5.0"
   },
   "peerDependencies": {
     "@marp-team/marpit": ">=0.5.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import { main, module as moduleFile, dependencies } from './package.json'
 
 const plugins = [
   json({ preferConst: true }),
-  nodeResolve({ jsnext: true }),
+  nodeResolve({ mainFields: ['module', 'jsnext:main', 'main'] }),
   commonjs(),
   typescript({ resolveJsonModule: false }),
   !process.env.ROLLUP_WATCH && terser(),
@@ -16,7 +16,7 @@ const plugins = [
 export default [
   {
     plugins,
-    external: Object.keys(dependencies),
+    external: Object.keys(dependencies || {}),
     input: `src/entry.ts`,
     output: { file: main, format: 'cjs', exports: 'named' },
   },

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,50 +1,26 @@
-import { detect } from 'detect-browser'
-
-let memoizedPolyfills: ((...args: any[]) => void)[] | undefined
-
-const webkitBrowsers = [
-  'android',
-  'bb10',
-  'crios',
-  'facebook',
-  'fxios',
-  'instagram',
-  'ios-webview',
-  'ios',
-  'phantomjs',
-  'safari',
-]
-
 export const symbolObserver = Symbol('MarpitSVGWebkitPolyfillObserver')
 
 export function observe() {
   if (window[symbolObserver]) return
-  window[symbolObserver] = true
 
-  if (polyfills().length === 0) return
+  Object.defineProperty(window, symbolObserver, {
+    configurable: true,
+    value: true,
+  })
 
-  const observer = () => {
-    for (const polyfill of polyfills()) polyfill()
-    window.requestAnimationFrame(observer)
+  const observedPolyfills = polyfills()
+
+  if (observedPolyfills.length > 0) {
+    const observer = () => {
+      for (const polyfill of observedPolyfills) polyfill()
+      window.requestAnimationFrame(observer)
+    }
+    observer()
   }
-
-  observer()
 }
 
-export function polyfills() {
-  if (!memoizedPolyfills) {
-    memoizedPolyfills = []
-
-    const { name } = detect() || <any>{}
-    if (webkitBrowsers.includes(name)) memoizedPolyfills.push(webkit)
-  }
-  return memoizedPolyfills
-}
-
-export function resetPolyfills() {
-  // Reset memoized polyfills for test
-  memoizedPolyfills = undefined
-}
+export const polyfills = () =>
+  navigator.vendor === 'Apple Computer, Inc.' ? [webkit] : []
 
 export function webkit(zoom?: number) {
   Array.from(document.getElementsByTagName('svg'), svg => {

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -1,9 +1,9 @@
-export const symbolObserver = Symbol('MarpitSVGWebkitPolyfillObserver')
+export const observerSymbol = Symbol()
 
 export function observe() {
-  if (window[symbolObserver]) return
+  if (window[observerSymbol]) return
 
-  Object.defineProperty(window, symbolObserver, {
+  Object.defineProperty(window, observerSymbol, {
     configurable: true,
     value: true,
   })

--- a/test/polyfill.ts
+++ b/test/polyfill.ts
@@ -1,10 +1,10 @@
 import { Marpit } from '@marp-team/marpit'
-import { observe, symbolObserver, webkit } from '../src/polyfill'
+import { observe, observerSymbol, webkit } from '../src/polyfill'
 
 let vendor: jest.SpyInstance
 
 beforeEach(() => {
-  window[symbolObserver] = false
+  window[observerSymbol] = false
   vendor = jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => '')
 })
 

--- a/test/polyfill.ts
+++ b/test/polyfill.ts
@@ -1,36 +1,28 @@
 import { Marpit } from '@marp-team/marpit'
-import * as detectBrowser from 'detect-browser'
-import {
-  observe,
-  resetPolyfills,
-  symbolObserver,
-  webkit,
-} from '../src/polyfill'
+import { observe, symbolObserver, webkit } from '../src/polyfill'
+
+let vendor: jest.SpyInstance
 
 beforeEach(() => {
-  resetPolyfills()
   window[symbolObserver] = false
+  vendor = jest.spyOn(navigator, 'vendor', 'get').mockImplementation(() => '')
 })
 
-afterEach(() => jest.restoreAllMocks())
-
 describe('Marpit SVG polyfill', () => {
-  const browseWith = (name: detectBrowser.BrowserInfo['name']) =>
-    jest
-      .spyOn(detectBrowser, 'detect')
-      .mockImplementation(() => ({ name, version: '0.0.0', os: null }))
-
   describe('#observe', () => {
-    it('has no operations when running in not supported browser', () => {
-      const spy = jest.spyOn(window, 'requestAnimationFrame')
+    let spy: jest.SpyInstance
 
+    beforeEach(() => {
+      spy = jest.spyOn(window, 'requestAnimationFrame')
+    })
+
+    it('has no operations when running in not supported browser', () => {
       observe()
       expect(spy).not.toBeCalled()
     })
 
     it('applies polyfill once when running in WebKit browser', () => {
-      browseWith('safari')
-      const spy = jest.spyOn(window, 'requestAnimationFrame')
+      vendor.mockImplementation(() => 'Apple Computer, Inc.')
 
       observe()
       expect(spy).toBeCalledTimes(1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,6 +392,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.5.tgz#ac14404c33d1a789973c45379a67f7f7e58a01b9"
   integrity sha512-CFLSALoE+93+Hcb5pFjp0J1uMrrbLRe+L1+gFwerJ776R3TACSF0kTVRQ7AvRa7aFx70nqYHAc7wQPlt9kY2Mg==
 
+"@types/node@^12.0.8":
+  version "12.0.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
+  integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
@@ -1029,11 +1034,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-detect-browser@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-4.5.0.tgz#6a726bd21e9dd77b4e18676515d48c88b4156ee3"
-  integrity sha512-uwyZNBwMhvRIOBIBTuDu+h4/a2bfFE/elUIvAOuKuBZcuy6yAJ/9dOe4r3wyWO/ZW2PcsP0dhEwiVwTPTTJp2Q==
 
 detect-libc@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
`detect-browser` module is too heavy just to detect WebKit. We've updated WebKit detection logic to use the value of [`navigator.vendor`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor). Any dependencies are no longer required.

According to WHATWG specification, it returns which of `Google, Inc.`, `Apple Computer, Inc.`, and the empty string. So we determine applying WebKit polyfill by whether there is `Apple Computer, Inc.` string.

It will be shrinked the built JS size dramatically. e.g. Build for browser becomes from 4568bytes to 947bytes. (about 5x smaller)