### PR TITLE
Use transformation matrix generated from getScreenCTM()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use transformation matrix generated from `getScreenCTM()` ([#30](https://github.com/marp-team/marpit-svg-polyfill/pull/30))
+
 ## v1.6.0 - 2020-08-16
 
 ### Added

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -97,8 +97,8 @@ export function webkit(opts?: number | (PolyfillOption & { zoom?: number })) {
         const matrix = fo.getScreenCTM()
 
         if (matrix) {
-          const x = fo.x.baseVal.value
-          const y = fo.y.baseVal.value
+          const x = fo.x?.baseVal.value ?? 0
+          const y = fo.y?.baseVal.value ?? 0
 
           const section = fo.firstChild as HTMLElement
           const { style } = section

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -105,11 +105,13 @@ export function webkit(opts?: number | (PolyfillOption & { zoom?: number })) {
 
           if (!style.transformOrigin) style.transformOrigin = `${-x}px ${-y}px`
 
+          // translateZ with non-zero value is required to work interactive
+          // content such as animation GIF, but it gets blurry text.
           style.transform = `scale(${zoomFactor}) matrix(${matrix.a}, ${
             matrix.b
           }, ${matrix.c}, ${matrix.d}, ${matrix.e - svgRect.left}, ${
             matrix.f - svgRect.top
-          })`
+          }) translateZ(0.0001px)`
         }
       }
     }

--- a/test/polyfill.ts
+++ b/test/polyfill.ts
@@ -75,11 +75,12 @@ describe('Marpit SVG polyfill', () => {
       const marpit = new Marpit({ inlineSVG: true })
       document.body.innerHTML = marpit.render('').html
 
-      Array.from(document.querySelectorAll('svg'), (svg: any) => {
-        jest.spyOn(svg, 'clientWidth', 'get').mockImplementation(() => 640)
-        jest.spyOn(svg, 'clientHeight', 'get').mockImplementation(() => 360)
-        svg.viewBox = { baseVal: { width: 1280, height: 720 } }
-      })
+      jest
+        .spyOn<any, any>(SVGElement.prototype, 'getBoundingClientRect')
+        .mockReturnValue({ left: 0, top: 0, width: 640, height: 360 })
+
+      const matrix = { a: 0.5, b: 0, c: 0, d: 0.5, e: 0, f: 0 }
+      ;(SVGElement.prototype as any).getScreenCTM = () => matrix
     })
 
     it('applies transform style to SVG element for repainting', () => {
@@ -97,14 +98,14 @@ describe('Marpit SVG polyfill', () => {
 
       Array.from(sections, ({ style }) => {
         expect(style.transformOrigin).toBeFalsy()
-        expect(style.transform).not.toContain('scale')
+        expect(style.transform).not.toContain('matrix')
       })
 
       webkit()
 
       Array.from(sections, ({ style }) => {
-        expect(style.transformOrigin).toBe('0 0')
-        expect(style.transform).toContain('scale(0.5)')
+        expect(style.transformOrigin).toBe('0px 0px')
+        expect(style.transform).toContain('matrix(0.5, 0, 0, 0.5, 0, 0)')
       })
     })
 
@@ -118,7 +119,7 @@ describe('Marpit SVG polyfill', () => {
       webkit()
 
       Array.from(document.getElementsByTagName('section'), ({ style }) =>
-        expect(style.transform).toContain('scale(0.625)')
+        expect(style.transform).toContain('scale(1.25)')
       )
     })
 
@@ -133,7 +134,7 @@ describe('Marpit SVG polyfill', () => {
       webkit()
 
       Array.from(document.getElementsByTagName('section'), ({ style }) =>
-        expect(style.transform).toContain('scale(1)')
+        expect(style.transform).toContain('scale(2)')
       )
     })
 


### PR DESCRIPTION
I've found `getScreenCTM()` will return the correct matrix for transformation even if using Safari. This PR makes scaling based on `getScreenCTM()`.

This way has many advantages compared to previous way:

- Reproducibllity of SVG got drastically better. Now polyfill obeys some SVG features such as `preserveaspectratio` attribute.
- `transform` CSS property got simpler, ~~and fixed blurred text (reported in https://github.com/marp-team/marp-cli/issues/225).~~
  - It seems to prevent working interactive contents like GIF animation. We've fixed by applying `translateZ(0.0001px)` with allowing blurred text.
- Fix rendering bug about sticky position caused by `position: fixed`.