### PR TITLE
Fix section detection to use firstElementChild instead of firstChild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Marpit's `<section>` detection to use `firstElementChild` instead of `firstChild` ([#33](https://github.com/marp-team/marpit-svg-polyfill/pull/33))
+
 ## v1.7.0 - 2020-08-18
 
 ### Changed

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -100,7 +100,7 @@ export function webkit(opts?: number | (PolyfillOption & { zoom?: number })) {
           const x = fo.x?.baseVal.value ?? 0
           const y = fo.y?.baseVal.value ?? 0
 
-          const section = fo.firstChild as HTMLElement
+          const section = fo.firstElementChild as HTMLElement
           const { style } = section
 
           if (!style.transformOrigin) style.transformOrigin = `${-x}px ${-y}px`


### PR DESCRIPTION
Reported in https://github.com/marp-team/marp-vscode/issues/192#issuecomment-774609261.