### PR TITLE
Make robust from element injection to foreignObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Breaking
 
-- Required Node 10 and later to install ([#45](https://github.com/marp-team/marpit-svg-polyfill/pull/45))
+- Required Node 10 and later to install (but recommend to use Node 14 and later) ([#45](https://github.com/marp-team/marpit-svg-polyfill/pull/45))
+
+### Fixed
+
+- Make robust from element injection to `<foreignObject>` ([#46](https://github.com/marp-team/marpit-svg-polyfill/pull/46))
 
 ### Changed
 

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -94,24 +94,37 @@ export function webkit(opts?: number | (PolyfillOption & { zoom?: number })) {
 
       for (let i = 0; i < length; i += 1) {
         const fo = svg.children[i] as SVGForeignObjectElement
-        const matrix = fo.getScreenCTM()
 
-        if (matrix) {
-          const x = fo.x?.baseVal.value ?? 0
-          const y = fo.y?.baseVal.value ?? 0
+        if (fo.getScreenCTM) {
+          const matrix = fo.getScreenCTM()
 
-          const section = fo.firstElementChild as HTMLElement
-          const { style } = section
+          if (matrix) {
+            const x = fo.x?.baseVal.value ?? 0
+            const y = fo.y?.baseVal.value ?? 0
 
-          if (!style.transformOrigin) style.transformOrigin = `${-x}px ${-y}px`
+            const foChildrenLength = fo.children.length
 
-          // translateZ with non-zero value is required to work interactive
-          // content such as animation GIF, but it gets blurry text.
-          style.transform = `scale(${zoomFactor}) matrix(${matrix.a}, ${
-            matrix.b
-          }, ${matrix.c}, ${matrix.d}, ${matrix.e - svgRect.left}, ${
-            matrix.f - svgRect.top
-          }) translateZ(0.0001px)`
+            for (let j = 0; j < foChildrenLength; j += 1) {
+              const section = fo.children[j] as Element
+
+              if (section.tagName === 'SECTION') {
+                const { style } = section as HTMLElement
+
+                if (!style.transformOrigin)
+                  style.transformOrigin = `${-x}px ${-y}px`
+
+                // translateZ with non-zero value is required to work interactive
+                // content such as animation GIF, but it gets blurry text.
+                style.transform = `scale(${zoomFactor}) matrix(${matrix.a}, ${
+                  matrix.b
+                }, ${matrix.c}, ${matrix.d}, ${matrix.e - svgRect.left}, ${
+                  matrix.f - svgRect.top
+                }) translateZ(0.0001px)`
+
+                break
+              }
+            }
+          }
         }
       }
     }

--- a/test/polyfill.ts
+++ b/test/polyfill.ts
@@ -109,6 +109,18 @@ describe('Marpit SVG polyfill', () => {
       })
     })
 
+    it('applies calculated transform style even if prepended unknown element before the section', () => {
+      expect.hasAssertions()
+
+      const section = document.getElementsByTagName('section')[0]
+      section.insertAdjacentHTML('beforebegin', '<div>unknown</div>')
+
+      webkit()
+
+      expect(section.style.transformOrigin).toBe('0px 0px')
+      expect(section.style.transform).toContain('matrix(0.5, 0, 0, 0.5, 0, 0)')
+    })
+
     it("takes account of SVG's currentScale property", () => {
       expect.hasAssertions()
 


### PR DESCRIPTION
marpit-svg-polyfill has assumed the first element of `<foreignObject>` as the slide element `<section>`. But this assumption sometimes break by the advanced customization of Marp ecosystem: marp-team/marp#284

In this PR, I have updated to find the first `<section>` from children of `<foreignObject>` correctly.